### PR TITLE
fix(settings): add probot settings employees team as readonly

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -42,6 +42,8 @@ teams:
     permission: admin
   - name: robot
     permission: pull
+  - name: employees
+    permission: pull
   - name: security
     permission: push
 

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -36,16 +36,11 @@ branches:
         users: []
 
 teams:
-  - name: sre
-    permission: admin
-  - name: robot-write
-    permission: admin
-  - name: robot
-    permission: pull
-  - name: employees
-    permission: pull
-  - name: security
-    permission: push
+  - { name: 'sre',          permission: 'admin' }
+  - { name: 'robot-write',  permission: 'admin' }
+  - { name: 'robot',        permission: 'pull' }
+  - { name: 'employees',    permission: 'pull' }
+  - { name: 'security',     permission: 'push' }
 
 labels:
 


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->
> Add probot settings employees team as readonly

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* n/a
